### PR TITLE
Fixes bugs with tinting and inserting buttons.

### DIFF
--- a/ATHMultiSelectionSegmentedControl.podspec
+++ b/ATHMultiSelectionSegmentedControl.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'ATHMultiSelectionSegmentedControl'
-  s.version          = '0.1.0'
+  s.version          = '0.1.1'
   s.summary          = 'A control mimicking UISegmentedControl behaviour but allowing for multiple segment selection'
 
   s.description      = <<-DESC

--- a/ATHMultiSelectionSegmentedControl/Classes/ATHMultiSelectionControlSegmentButton.swift
+++ b/ATHMultiSelectionSegmentedControl/Classes/ATHMultiSelectionControlSegmentButton.swift
@@ -81,10 +81,11 @@ internal class ATHMultiSelectionControlSegmentButton: UIButton {
      Styles the button as selected
     */
     private func _setSelectedState() {
-        
+
+        layer.borderColor = backgroundColor?.CGColor
         backgroundColor = tintColor
         setTitleColor(UIColor.whiteColor(), forState: .Normal)
-        
+
     }
     
     /**
@@ -94,6 +95,7 @@ internal class ATHMultiSelectionControlSegmentButton: UIButton {
         
         backgroundColor = UIColor.clearColor()        
         setTitleColor(tintColor, forState: .Normal)
+        layer.borderColor = tintColor.CGColor
         
     }
     

--- a/ATHMultiSelectionSegmentedControl/Classes/ATHMultiSelectionSegmentedControl.swift
+++ b/ATHMultiSelectionSegmentedControl/Classes/ATHMultiSelectionSegmentedControl.swift
@@ -43,6 +43,21 @@ public class MultiSelectionSegmentedControl: UIView {
     override public var tintColor: UIColor! {
         didSet {
             layer.borderColor = tintColor.CGColor
+            if let segmentButtons = _segmentButtons {
+                for (index, button) in segmentButtons.enumerate() {
+                    button.highlighted = selectedSegmentIndices.contains(index)
+                }
+            }
+        }
+    }
+
+    public override var backgroundColor: UIColor? {
+        didSet {
+            if let segmentButtons = _segmentButtons {
+                for (index, button) in segmentButtons.enumerate() {
+                    button.highlighted = selectedSegmentIndices.contains(index)
+                }
+            }
         }
     }
     
@@ -133,28 +148,41 @@ public class MultiSelectionSegmentedControl: UIView {
         if subviews.count == 0 {
 
             _segmentButtons = []
-            
+
+
+            let buttonWidth = frame.width / CGFloat(items.count)
+            let buttonHeight = frame.height
+
             for (index, segmentTitle) in items.enumerate() {
-                
-                let buttonWidth = frame.width / CGFloat(items.count)
-                let buttonHeight = frame.height
-                
                 let buttonFrame = CGRectMake(CGFloat(index)*buttonWidth, 0, buttonWidth, buttonHeight)
 
                 let button = ATHMultiSelectionControlSegmentButton(frame: buttonFrame)
-                
+
                 button.tintColor = tintColor
                 button.backgroundColor = backgroundColor
+                button.setButtonSelected(selectedSegmentIndices.contains(index))
                 button.addTarget(self, action: #selector(self._didTouchUpInsideSegment(_:)), forControlEvents: .TouchUpInside)
-                
+
                 button.setTitle(segmentTitle, forState: .Normal)
 
                 _segmentButtons?.append(button)
                 
                 self.addSubview(button)
-
+                
             }
             
+        }
+        else {
+            if let segmentButtons = _segmentButtons {
+                let buttonWidth = frame.width / CGFloat(segmentButtons.count)
+                let buttonHeight = frame.height
+
+                for (index, button) in segmentButtons.enumerate() {
+                    let buttonFrame = CGRectMake(CGFloat(index)*buttonWidth, 0, buttonWidth, buttonHeight)
+                    button.frame = buttonFrame
+                    button.setButtonSelected(selectedSegmentIndices.contains(index))
+                }
+            }
         }
     
     }
@@ -383,7 +411,7 @@ public class MultiSelectionSegmentedControl: UIView {
     */
     private func _configureAppearance() {
         
-        backgroundColor = UIColor.clearColor()
+//        backgroundColor = UIColor.clearColor()
         layer.cornerRadius = cornerRadius
         layer.masksToBounds = true
         layer.borderWidth = 1.0


### PR DESCRIPTION
```
segmentedControl = MultiSelectionSegmentedControl(items: nil)
segmentedControl.tintColor = UIColor.greenColor()
segmentedControl.backgroundColor = UIColor.yellowColor()
// ...
segmentedControl.insertSegmentWithTitle("Index 0", atIndex: 0, animated: false)
segmentedControl.insertSegmentWithTitle("Index 1", atIndex: 1, animated: false)
segmentedControl.insertSegmentWithTitle("Index 2", atIndex: 2, animated: false)
```

If you try this code on the current version of the library, you wouldn't get the correct colors nor the texts to be displayed.

My PR attempts to fix this.
