### PR TITLE
Modify deployment target from 10.1 to 10.0

### DIFF
--- a/Example/ATHMultiSelectionSegmentedControl.xcodeproj/project.pbxproj
+++ b/Example/ATHMultiSelectionSegmentedControl.xcodeproj/project.pbxproj
@@ -623,7 +623,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ATHMultiSelectionSegmentedControl/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.attheodo.ATHMultiSelectionSegmentedControl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -653,7 +653,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = ATHMultiSelectionSegmentedControl/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.attheodo.ATHMultiSelectionSegmentedControl;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -824,6 +824,7 @@
 				4D99380C1DD8B44D00DAD213 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "ATHMultiSelectionSegmentedControl" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
As the name says, this PR changes the deployment target version. One of my apps has its target at 10.0, and since there are no great changes from 10.0 to 10.1, I believe your framework's deployment should target the lesser. Unless it is intended. If so, could you explain why?

Thanks for the attention! o/